### PR TITLE
Fix: id 기반 프로필 데이터 가져오기에서 membername 기반으로 변경

### DIFF
--- a/src/app/(default)/collection/[id]/page.tsx
+++ b/src/app/(default)/collection/[id]/page.tsx
@@ -28,7 +28,7 @@ export async function generateMetadata({
     authors: [
       {
         name: `${collectionInfo.writerMembername}`,
-        url: `https://pintogether.com/profile/${collectionInfo.writerId}`,
+        url: `https://pintogether.com/profile/${collectionInfo.writerMembername}`,
       },
     ],
     generator: "Next.js 14",

--- a/src/app/(default)/profile/[membername]/page.tsx
+++ b/src/app/(default)/profile/[membername]/page.tsx
@@ -2,9 +2,10 @@ import ProfilePage from "@/containers/profile/ProfilePage";
 import SubPageLayout from "@/containers/layout/SubPageLayout";
 
 type PageParams = {
-  id: number;
+  id?: number;
+  membername?: string;
 };
 
 export default function Page({ params }: { params: PageParams }) {
-  return <ProfilePage userId={params.id} />;
+  return <ProfilePage membername={params.membername || ""} />;
 }

--- a/src/components/CollectionCard.tsx
+++ b/src/components/CollectionCard.tsx
@@ -288,7 +288,7 @@ const DefaultCollectionCard = ({
       <div className={styles.textContainer}>
         <Link
           className={styles.nickname}
-          href={`/profile/${collectionData.writerId}`}
+          href={`/profile/${collectionData.writerMembername}`}
         >{`@${collectionData.writerMembername}`}</Link>
         <Link
           href={`/collection/${collectionData.id}`}
@@ -379,7 +379,7 @@ const HorizontalCollectionCard = ({
           {collectionData.title}
         </Link>
         <Link
-          href={`/profile/${collectionData.writerId}`}
+          href={`/profile/${collectionData.writerMembername}`}
           className={styles.nickname}
           aria-disabled={linkDisabled}
         >{`@${collectionData.writerMembername}`}</Link>
@@ -473,7 +473,7 @@ const HorizontalDetailCollectionCard = ({
           {collectionData.title}
         </Link>
         <Link
-          href={`/profile/${collectionData.writerId}`}
+          href={`/profile/${collectionData.writerMembername}`}
           className={styles.nickname}
           aria-disabled={linkDisabled}
         >{`@${collectionData.writerMembername}`}</Link>

--- a/src/components/ReviewCard.tsx
+++ b/src/components/ReviewCard.tsx
@@ -17,7 +17,7 @@ export default function ReviewCard({
 
   return (
     <article className={styles.review}>
-      <Link href={`/profile/${reviewData.writerId}`}>
+      <Link href={`/profile/${reviewData.writerMembername}`}>
         <Image
           src={reviewData.avatarImage || defaultAvatarUrl || ""} // avatar
           alt="user profile image"
@@ -26,7 +26,7 @@ export default function ReviewCard({
           className={styles.userAvatar}
         />
       </Link>
-      <Link href={`/profile/${reviewData.writerId}`}>
+      <Link href={`/profile/${reviewData.writerMembername}`}>
         <span
           className={styles.userNick}
         >{`@${reviewData.writerMembername}`}</span>

--- a/src/containers/collection/CollectionEditPage.tsx
+++ b/src/containers/collection/CollectionEditPage.tsx
@@ -126,7 +126,7 @@ export default function CollectionEditPage({
     if (!success) {
       setAlertMessage(errorMessage);
     } else {
-      router.push(`/profile/${collectionInfo?.writerId}`);
+      router.push(`/profile/${collectionInfo?.writerMembername}`);
     }
     setIsUploading(false);
   };

--- a/src/containers/collection/CollectionInfoRenderer.tsx
+++ b/src/containers/collection/CollectionInfoRenderer.tsx
@@ -130,7 +130,7 @@ const CollectionInfoRenderer = ({
           )}
         </div>
         <Link
-          href={`/profile/${collectionData.writerId}`}
+          href={`/profile/${collectionData.writerMembername}`}
           className={styles.collectionWriter}
         >{`@${collectionData.writerMembername}`}</Link>
         <p className={styles.collectionTags}>

--- a/src/containers/layout/Sidebar.tsx
+++ b/src/containers/layout/Sidebar.tsx
@@ -125,7 +125,7 @@ export default function Sidebar() {
               className={`${styles.profile}`}
               width={size}
               height={size}
-              onClick={() => moveURL(`/profile/${profile.id}`)}
+              onClick={() => moveURL(`/profile/${profile.membername}`)}
             />
           </div>
         ) : (

--- a/src/containers/profile/FollowPage.tsx
+++ b/src/containers/profile/FollowPage.tsx
@@ -110,7 +110,7 @@ const UserCard = ({
 
   return (
     <article className={styles.userCard}>
-      <Link href={`/profile/${user.id}`} className={styles.userAvatar}>
+      <Link href={`/profile/${user.membername}`} className={styles.userAvatar}>
         <Image
           src={user.avatar}
           alt="user profile image"
@@ -118,7 +118,7 @@ const UserCard = ({
           height={100}
         />
       </Link>
-      <Link href={`/profile/${user.id}`} className={styles.names}>
+      <Link href={`/profile/${user.membername}`} className={styles.names}>
         <div className={styles.userMembername}>{`${user.membername}`}</div>
         <div className={styles.userName}>{`${user.name} name`}</div>
       </Link>

--- a/src/containers/profile/ProfileEditPage.tsx
+++ b/src/containers/profile/ProfileEditPage.tsx
@@ -165,7 +165,7 @@ export default function ProfileEditPage() {
     );
     if (success) {
       updateReduxProfile();
-      router.push(`/profile/${myProfile.id}`);
+      router.push(`/profile/${myProfile.membername}`);
     } else setTotalErrorMessage(errorMessage);
   };
 

--- a/src/containers/profile/ProfilePage(id).tsx
+++ b/src/containers/profile/ProfilePage(id).tsx
@@ -14,12 +14,11 @@ import { useRouter } from "next/navigation";
 
 import { ProfileOthers } from "@/types/Profile";
 import fetchGetProfileInfo from "@/utils/members/fetchGetProfileInfo";
-import fetchGetProfileInfoByMembername from "@/utils/members/fetchGetProfileInfoByMembername"; ///
 import useCheckIsMyId from "@/hooks/useCheckIsMyId";
 
-export default function ProfilePage({ membername }: { membername: string }) {
+export default function ProfilePage({ userId }: { userId: number }) {
   const router = useRouter();
-  const [isMyProfile, setIsMyProfile] = useState(false);
+  const isMyProfile = useCheckIsMyId(userId);
 
   /* fetch data */
   const [isLoading, setIsLoading] = useState(false);
@@ -29,15 +28,14 @@ export default function ProfilePage({ membername }: { membername: string }) {
   } | null>(null);
   const fetchProfileFetchData = async () => {
     setIsLoading(true);
-    const result = await fetchGetProfileInfoByMembername(membername);
+    const result = await fetchGetProfileInfo(userId);
     setProfileFetchData(result);
-    setIsMyProfile(useCheckIsMyId(result.profileInfo?.id || -1));
     setIsLoading(false);
   };
 
   useEffect(() => {
     if (!isLoading) fetchProfileFetchData();
-  }, [membername]);
+  }, [userId]);
 
   /* button state */
   const [showState, setShowState] = useState(1);
@@ -60,7 +58,7 @@ export default function ProfilePage({ membername }: { membername: string }) {
       completeButtonMsg={isMyProfile ? "수정" : undefined}
       onClickCompleteButton={hanldeClickCompleteButton}
     >
-      {!profileFetchData?.profileInfo ? (
+      {!profileFetchData ? (
         <ProfileSkeleton />
       ) : profileFetchData.errorMessage ? (
         <div className={styles.errorMessage}>
@@ -69,7 +67,7 @@ export default function ProfilePage({ membername }: { membername: string }) {
       ) : (
         <>
           <ProfileInfoRenderer
-            userId={profileFetchData.profileInfo.id}
+            userId={userId}
             profileInfo={profileFetchData.profileInfo}
             errorMessage={profileFetchData.errorMessage}
             isMyProfile={isMyProfile}
@@ -112,21 +110,18 @@ export default function ProfilePage({ membername }: { membername: string }) {
           {/* TODO : 버튼 클릭시 마다 재랜더링이 되지 않도록(fetch 여러번) dispaly : none 으로 화면 제어하기*/}
           {showState === 1 && (
             <ProfileCollectionsRenderer
-              userId={profileFetchData.profileInfo.id}
+              userId={userId}
               isMyProfile={isMyProfile}
             />
           )}
           {showState === 2 && (
-            <ProfileScrapsRenderer
-              userId={profileFetchData.profileInfo.id}
-              isMyProfile={isMyProfile}
-            />
+            <ProfileScrapsRenderer userId={userId} isMyProfile={isMyProfile} />
           )}
           {/* {showState === 3 && (
         <ProfileCollectionRenderer collectionList={followCollections} />
       )} */}
           {showState === 4 && isMyProfile && (
-            <ProfileStarredRenderer userId={profileFetchData.profileInfo.id} />
+            <ProfileStarredRenderer userId={userId} />
           )}
         </>
       )}

--- a/src/containers/profile/ProfilePage.tsx
+++ b/src/containers/profile/ProfilePage.tsx
@@ -16,10 +16,11 @@ import { ProfileOthers } from "@/types/Profile";
 import fetchGetProfileInfo from "@/utils/members/fetchGetProfileInfo";
 import fetchGetProfileInfoByMembername from "@/utils/members/fetchGetProfileInfoByMembername"; ///
 import useCheckIsMyId from "@/hooks/useCheckIsMyId";
+import useCheckIsMyMembername from "@/hooks/useCheckIsMyMembername";
 
 export default function ProfilePage({ membername }: { membername: string }) {
   const router = useRouter();
-  const [isMyProfile, setIsMyProfile] = useState(false);
+  const isMyProfile = useCheckIsMyMembername(membername);
 
   /* fetch data */
   const [isLoading, setIsLoading] = useState(false);
@@ -31,7 +32,6 @@ export default function ProfilePage({ membername }: { membername: string }) {
     setIsLoading(true);
     const result = await fetchGetProfileInfoByMembername(membername);
     setProfileFetchData(result);
-    setIsMyProfile(useCheckIsMyId(result.profileInfo?.id || -1));
     setIsLoading(false);
   };
 

--- a/src/hooks/useCheckIsMyMembername.tsx
+++ b/src/hooks/useCheckIsMyMembername.tsx
@@ -1,0 +1,17 @@
+import { useAppSelector } from "@/redux/hooks";
+
+const useCheckIsMyMembername = (membername: string) => {
+  const myProfileState = useAppSelector((state) => state.myProfile);
+
+  try {
+    if (myProfileState) {
+      return myProfileState.membername == membername;
+    } else {
+      return false;
+    }
+  } catch (error) {
+    // console.error("checkIsMyId", error);
+    return false;
+  }
+};
+export default useCheckIsMyMembername;

--- a/src/types/Profile.tsx
+++ b/src/types/Profile.tsx
@@ -16,6 +16,7 @@ export interface ProfileMine extends Profile {
 }
 
 export interface ProfileOthers extends Profile {
+  id: number;
   bio: string;
   scrappedCollectionCnt: number;
   followerCnt: number;

--- a/src/utils/members/fetchGetProfileInfoByMembername.tsx
+++ b/src/utils/members/fetchGetProfileInfoByMembername.tsx
@@ -2,15 +2,15 @@ import { ProfileOthers } from "@/types/Profile";
 import APIResponse from "@/types/APIResponse";
 import { logout } from "@/hooks/useLogout";
 
-const fetchGetProfileInfo = async (userId: number) => {
+const fetchGetProfileInfoByMembername = async (userMembername: string) => {
   try {
     const res = await fetch(
-      `${process.env.NEXT_PUBLIC_BACKEND_URL}/members/id/${userId}`,
+      `${process.env.NEXT_PUBLIC_BACKEND_URL}/members/${userMembername}`,
       {
         credentials: "include",
       }
     );
-    console.log("fetchGetProfileInfo res", res);
+    console.log("fetchGetProfileInfoByMembername res", res);
     if (res.status === 401) {
       logout();
       return {
@@ -26,7 +26,7 @@ const fetchGetProfileInfo = async (userId: number) => {
     }
     if (!res.ok) throw new Error("프로필 가져오기에 실패했습니다.");
     const data: APIResponse = await res.json();
-    console.log("fetchGetProfileInfo data", data);
+    console.log("fetchGetProfileInfoByMembername data", data);
     const profileInfo: ProfileOthers = data.results[0];
     return { profileInfo, errorMessage: "" };
   } catch (err: any) {
@@ -37,4 +37,4 @@ const fetchGetProfileInfo = async (userId: number) => {
     };
   }
 };
-export default fetchGetProfileInfo;
+export default fetchGetProfileInfoByMembername;


### PR DESCRIPTION
<!--
  🚨PR 전에 해야할 것들🚨
  * PR 제목에 type 적기(ex Feature)
  * reviewer 등록하기
  * assignees 등록하기
  * label 붙이기
  * 브랜치 Merge 후 해당 브랜치 삭제하기
-->
## 🛠️ 변경 사항
- fix: id 기반 프로필 데이터 가져오기에서 membername 기반으로 변경
- 

<br/>

## 📝 주의 사항 & 리뷰 요청
- 프로필 조회 페이지에서 유저데이터를 요청할 때 아직 유저 id 를 못받아와서, 
  id 에 의존하는 컬렉션 목록, 찜목록, 스크랩 목록을 불러오기에 실패하는 오류가 생길 수 있습니다.

<br/>

## ⚡️ Issue number & Link

<br/>

## 📸 ScreenShot

<br/>
