### PR TITLE
Fix/ URI 인코딩, useEffect 순환문제 해결 #128

### DIFF
--- a/src/components/SlideMenu.tsx
+++ b/src/components/SlideMenu.tsx
@@ -11,7 +11,7 @@ const SlideMenu = ({
 }: {
   menuTitleList: string[];
   customSelectedMenu?: number;
-  customSetSelectedMenu?: React.Dispatch<React.SetStateAction<number>>;
+  customSetSelectedMenu?: (index: number) => void;
   children: React.ReactNode[];
 }) => {
   const [selectedMenu, setSelectedMenu] = useState<number>(0);

--- a/src/containers/main/MainPage.tsx
+++ b/src/containers/main/MainPage.tsx
@@ -125,13 +125,15 @@ export default function MainPage() {
 
   const enterKeyDown = (e: any) => {
     if (e.key === "Enter" && inputCollectionSearch != "") {
-      router.push(`/search?keyword=${inputCollectionSearch}`);
+      const keyword = encodeURIComponent(inputCollectionSearch);
+      router.push(`/search?keyword=${keyword}`);
     }
   };
 
   const searchButtonClick = () => {
     if (inputCollectionSearch != "") {
-      router.push(`/search?keyword=${inputCollectionSearch}`);
+      const keyword = encodeURIComponent(inputCollectionSearch);
+      router.push(`/search?keyword=${keyword}`);
     }
   };
 

--- a/src/containers/search/SearchLogContent.tsx
+++ b/src/containers/search/SearchLogContent.tsx
@@ -28,7 +28,7 @@ function SearchLogContent({
   return (
     <div className={styles.searchLogContent}>
       <Link
-        href={`/search?keyword=${searchKeyword}`}
+        href={`/search?keyword=${encodeURIComponent(searchKeyword)}`}
         className={styles.searchLog}
       >
         <SearchIcon className={styles.searchIcon} />

--- a/src/hooks/useCheckIsMyMembername.tsx
+++ b/src/hooks/useCheckIsMyMembername.tsx
@@ -4,8 +4,12 @@ const useCheckIsMyMembername = (membername: string) => {
   const myProfileState = useAppSelector((state) => state.myProfile);
 
   try {
+    console.log("myProfileState", myProfileState);
+    console.log("membername", membername);
     if (myProfileState) {
-      return myProfileState.membername == membername;
+      const decodedMembername = decodeURIComponent(membername);
+      console.log("decodedMembername", decodedMembername);
+      return myProfileState.membername == decodedMembername;
     } else {
       return false;
     }


### PR DESCRIPTION
<!--
  🚨PR 전에 해야할 것들🚨
  * PR 제목에 type 적기(ex Feature)
  * reviewer 등록하기
  * assignees 등록하기
  * label 붙이기
  * 브랜치 Merge 후 해당 브랜치 삭제하기
-->
## 🛠️ 변경 사항
- SearchPage 에서 특수 기호 입력시, 검색 keyword 를 적질히 읽어오지 못하는 오류 해결
- SearchPage 에서 URI 쿼리스트링으로 검색시 keyword 값이 없어지는 오류 해결
  - selectedMenu가 의존성 배열로 들어있는 useEffect 와 ,  searchParams 가 의존성 배열로 들어있는 useEffect 의 순환 문제

-  `useCheckIsMyMembername` 에서 membername 을 적절히 비교하지 못하여, 내 프로필임에도 타인의 프로필 볼때의 화면이 뜨는 문제
    - 같은 문제로 membername 정책 도입전의 nickname 값이 membername 에 들어가면서 공백문자가 들어가고,
  인코딩 되어 가져온 URI 의 값을 적절히 디코딩해주지 않고 있었음

<br/>

## 📝 주의 사항 & 리뷰 요청

<br/>

## ⚡️ Issue number & Link
- #128 

<br/>

## 📸 ScreenShot

<br/>
