### PR TITLE
Feat/overlay collection 리스트 관련 오류 #116

### DIFF
--- a/src/containers/overlay/Overlay.tsx
+++ b/src/containers/overlay/Overlay.tsx
@@ -309,13 +309,16 @@ export default function Overlay() {
   }
 
   useEffect(() => {
+    if(cleanSelectedCollection)
       makeMarkerList();
+    else
+      dispatch(cleanSelectedCollectionByAmount(false));
   }, [markerDatas]);
 
   useEffect(() => {
     if(cleanSelectedCollection){
       setSelectedCardId([]);
-      dispatch(cleanSelectedCollectionByAmount(false));
+      setMarkerDatas([]);
     }
   },[cleanSelectedCollection])
 


### PR DESCRIPTION

## 🛠️ 변경 사항
- overlay collection의 선택이 해제될 때 마커 데이터가 초기화되야 하지만 초기화 되지않고 기존의 마커들이 남아있다가 새 마커가 생성될 때 함께 생성되던 문제 해결
<br/>

<br/>

## ⚡️ Issue number & Link
- #119 
- 

<br/>
