### PR TITLE
fix: 빈문자열 검색 가능하도록 수정

### DIFF
--- a/src/containers/search/SearchPage.tsx
+++ b/src/containers/search/SearchPage.tsx
@@ -34,10 +34,9 @@ export default function Page() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [searchInputValue, setSearchInputValue] = useState("");
-  const [showSearchLog, setShowSearchLog] = useState(true);
   const [searchKeyword, setSearchKeyword] = useState("");
   const [selectedMenu, setSelectedMenu] = useState<number>(
-    SearchCategory.PLACE
+    SearchCategory.HISTORY
   );
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
@@ -52,7 +51,7 @@ export default function Page() {
     const search = async (type: string, keyword: string) => {
       if (isLoading) return;
       setIsLoading(true);
-      if (keyword) {
+      if (searchParams.has("keyword")) {
         const getDecodeKeyword = (keyword: string) => {
           try {
             const decodeKeyword = decodeURIComponent(keyword);
@@ -65,7 +64,6 @@ export default function Page() {
         const decodeKeyword = getDecodeKeyword(keyword);
         const convertedRangeFileter = convertToRangeFilter(newRangefilter);
         setSearchInputValue(decodeKeyword);
-        setShowSearchLog(false);
         setSearchKeyword(decodeKeyword);
         setRangeFilter(convertedRangeFileter);
         if (decodeKeyword && (!type || type === "history")) {
@@ -73,8 +71,8 @@ export default function Page() {
         } else setSelectedMenu(convertToSearchCategory(type));
       } else {
         console.log("검색어가 없습니다.");
-        setShowSearchLog(true);
         setSearchInputValue("");
+        // setSearchKeyword(""); // ?
         setSelectedMenu(SearchCategory.HISTORY);
         setRangeFilter(RangeFilter.MAP);
       }
@@ -82,10 +80,6 @@ export default function Page() {
     };
     search(type || "", keyword || "");
   }, [searchParams]);
-
-  useEffect(() => {
-    console.log("rangeFilter!", rangeFilter);
-  }, [rangeFilter]);
 
   const convertToSearchCategory = (type: string) => {
     switch (type) {
@@ -154,7 +148,8 @@ export default function Page() {
     e: React.FormEvent<HTMLFormElement> | React.MouseEvent<HTMLButtonElement>
   ) => {
     e.preventDefault();
-    const type = searchParams.get("type") || "";
+    const type =
+      searchParams.get("type") || convertToType(SearchCategory.PLACE);
     const keyword = encodeURIComponent(searchInputValue);
     const newRangefilter = rangeFilter;
     router.push(
@@ -232,7 +227,7 @@ export default function Page() {
       )}
       {/* 검색 결과 */}
       <section className={styles.searchInnerPage} ref={pageRef}>
-        {showSearchLog ? (
+        {selectedMenu === SearchCategory.HISTORY ? (
           <SearchLogRenderer />
         ) : (
           <SlideMenu


### PR DESCRIPTION
<!--
  🚨PR 전에 해야할 것들🚨
  * PR 제목에 type 적기(ex Feature)
  * reviewer 등록하기
  * assignees 등록하기
  * label 붙이기
  * 브랜치 Merge 후 해당 브랜치 삭제하기
-->
## 🛠️ 변경 사항
- 검색페이지에서 빈문자열 검색가능하도록 수정하였습니다.

<br/>

## 📝 주의 사항 & 리뷰 요청
- 지도가 움직일때마다 검색이 새로되도록 하면 좋겠다고 하셔서 조금 만들었었는데,(pr에 같이 올리진 않았습니다)
  제 생각에는 검색 결과를 지도에서 확인하기 불편할 것 같습니다. 
  결과를 지도에서 보기 위해 지도를 움직이면 기존 검색 결과가 싹 사라지고, 새롭게 검색이 되어버리니까요
그래서 제 의견은 overlay에 추가해 주신 "지도 범위 장소"로 충분하지 않을까 하는 생각입니다 ! 어떻게 생각하시나요?
+ 추가로 "지도 범위 핀" 버튼도 있으면 좋을 것 같습니다 ~

<br/>

## ⚡️ Issue number & Link

<br/>

## 📸 ScreenShot

<br/>
