### PR TITLE
Feat/ collection 조회 페이지에 컬렉션 삭제 버튼 추가, Fix/ api 문서 속성이름 오기 수정 , 핀정보 없이 핀 수정페이지 접근 처리

### DIFF
--- a/src/components/UserCard.tsx
+++ b/src/components/UserCard.tsx
@@ -18,7 +18,7 @@ const UserCard = ({
   showUnfollowButton?: boolean;
 }) => {
   const dispatch = useAppDispatch();
-  const [isFollowing, setIsFollowing] = useState(user.isFollowed ?? true);
+  const [isFollowing, setIsFollowing] = useState(user.followed ?? true);
   const [isLoading, setIsLoading] = useState(false);
 
   const handleFollow = async () => {

--- a/src/containers/collection/CollectionPage.tsx
+++ b/src/containers/collection/CollectionPage.tsx
@@ -25,6 +25,8 @@ import CollectionWithPinRenderer from "@/containers/collection/CollectionWithPin
 import CollectionReplyRenderer from "@/containers/collection/CollectionReplyRenderer";
 import CollectionInfoRenderer from "@/containers/collection/CollectionInfoRenderer";
 import CollectionPageSkeleton from "./CollectionPageSkeleton";
+import { addAlertMessage } from "@/redux/globalAlertSlice";
+import fetchDeleteCollection from "@/utils/collections/fetchDeleteCollection";
 
 enum ShowState {
   PIN_PLACE = 1,
@@ -90,6 +92,32 @@ export default function CollectionPage({
     const result = await fetchGetCollectionComments(collectionId);
     setReplyFetchDatas(result);
     setIsReplyFetching(false);
+  };
+
+  /* 컬렉션 삭제 */
+  const deleteCollection = async () => {
+    if (
+      isCollectionFetching ||
+      !collectionId ||
+      !collectionFetchDatas.collectionInfo
+    )
+      return;
+    if (
+      !confirm(
+        `"${collectionFetchDatas.collectionInfo.title}" 컬렉션을 삭제하시겠습니까?`
+      )
+    )
+      return;
+    setIsCollectionFetching(true);
+    const { success, errorMessage } = await fetchDeleteCollection(collectionId);
+    if (!success) {
+      dispatch(addAlertMessage(errorMessage));
+    } else {
+      router.push(
+        `/profile/${collectionFetchDatas.collectionInfo.writerMembername}`
+      );
+    }
+    setIsCollectionFetching(false);
   };
 
   /* button state */
@@ -160,9 +188,11 @@ export default function CollectionPage({
     <SubPageLayout
       topperMsg={"컬렉션 조회"}
       completeButtonMsg={isMyCollection ? "수정" : undefined}
+      deleteButtonMsg={isMyCollection ? "삭제" : undefined}
       onClickCompleteButton={() =>
         router.push(`/collection/edit/${collectionId}`)
       }
+      onClickDeleteButton={() => deleteCollection()}
     >
       {isCollectionFetching ? (
         <CollectionPageSkeleton />

--- a/src/containers/pin/PinEditPage.tsx
+++ b/src/containers/pin/PinEditPage.tsx
@@ -111,6 +111,7 @@ export default function PinEditPage({ pinId }: { pinId?: string }) {
       return;
     } else {
       const collectionEditId = searchParams.get("collectionEditId");
+      if (!collectionEditId || pinData.id === -1) router.back();
       if (collectionEditId) setCollectionEditId(collectionEditId);
       setImageFiles(
         pinData.imagePaths.map((imagePath, index) => ({

--- a/src/types/Profile.tsx
+++ b/src/types/Profile.tsx
@@ -26,7 +26,7 @@ export interface ProfileOthers extends Profile {
 
 export interface ProfileFollower extends Profile {
   id: number;
-  isFollowed?: boolean;
+  followed?: boolean;
 }
 
 interface ERDMember {


### PR DESCRIPTION
<!--
  🚨PR 전에 해야할 것들🚨
  * PR 제목에 type 적기(ex Feature)
  * reviewer 등록하기
  * assignees 등록하기
  * label 붙이기
  * 브랜치 Merge 후 해당 브랜치 삭제하기
-->
## 🛠️ 변경 사항
-  api 문서 속성이름 오기 수정 
  - `isFollowed` => `followed` 
-  핀 정보없이(잘못된 경로로) 핀 수정페이지 들어왔을때 라우팅 뒤로가기 처리
   - ex) 핀 수정 완료 후 뒤로가기 버튼 클릭시 
- collection 조회 페이지에 컬렉션 삭제 버튼 추가

<br/>

## 📝 주의 사항 & 리뷰 요청

<br/>

## ⚡️ Issue number & Link

<br/>

## 📸 ScreenShot
![image](https://github.com/PinTogether/frontend/assets/89989211/587bdb80-aed3-4b26-a539-dea75561c134)


<br/>
