### PR TITLE
Feat/ ImageViewBox 구현 #159, Fix/ push.replace 로 페이지 재접근 방지 #171

### DIFF
--- a/src/components/ImageViewBox.tsx
+++ b/src/components/ImageViewBox.tsx
@@ -1,0 +1,81 @@
+import Image from "next/image";
+import Link from "next/link";
+import { useState, useEffect, Dispatch, SetStateAction } from "react";
+
+import styles from "@/styles/components/_imageViewBox.module.scss";
+import { CloseRoundIcon, ExpandLeftIcon, ExpandRightIcon } from "./IconSvg";
+
+const ImageViewBox = ({
+  review,
+  membername,
+  imagePaths,
+  selectedImageNum,
+  setSelectedImageNum,
+}: {
+  review: string;
+  membername: string;
+  imagePaths: string[];
+  selectedImageNum: number | null;
+  setSelectedImageNum: Dispatch<SetStateAction<number | null>>;
+}) => {
+  const [currentImagePath, setCurrentImagePath] = useState<number | null>(
+    selectedImageNum
+  );
+
+  const handleClickCloseButton = () => {
+    setCurrentImagePath(null);
+    setSelectedImageNum(null);
+  };
+
+  const handleClickButton = (increment: number) => {
+    if (currentImagePath === null) return;
+    const newImagePath = currentImagePath + increment;
+    if (newImagePath >= 0 && newImagePath < imagePaths.length) {
+      setCurrentImagePath(newImagePath);
+    }
+  };
+
+  useEffect(() => {
+    setCurrentImagePath(selectedImageNum);
+  }, [selectedImageNum]);
+
+  if (imagePaths.length <= 0 || currentImagePath === null) return <></>;
+  return (
+    <section className={styles.imageViewBox}>
+      <article className={styles.imageViewContainer}>
+        <div className={styles.imageContainer}>
+          <Image
+            className={styles.image}
+            src={imagePaths[currentImagePath]}
+            width={700}
+            height={700}
+            alt={"review iamge"}
+          />
+          {currentImagePath !== 0 && (
+            <ExpandLeftIcon
+              className={styles.leftButton}
+              onClick={() => handleClickButton(-1)}
+            />
+          )}
+          {currentImagePath !== imagePaths.length - 1 && (
+            <ExpandRightIcon
+              className={styles.rightButton}
+              onClick={() => handleClickButton(1)}
+            />
+          )}
+        </div>
+        <div className={styles.reviewContainer}>
+          <Link href={`/profile/${membername}`}>
+            <h3 className={styles.membername}>{`@${membername}의 리뷰`}</h3>
+          </Link>
+          <span className={styles.review}>{review}</span>
+        </div>
+      </article>
+      <CloseRoundIcon
+        id={styles.closeButton}
+        onClick={handleClickCloseButton}
+      />
+    </section>
+  );
+};
+export default ImageViewBox;

--- a/src/components/ReviewCard.tsx
+++ b/src/components/ReviewCard.tsx
@@ -4,6 +4,8 @@ import Pin from "@/types/Pin";
 import { CommentIcon } from "./IconSvg";
 import Link from "next/link";
 import MultilineTextRenderer from "@/components/MultilineTextRenderer";
+import ImageViewBox from "./ImageViewBox";
+import { useState } from "react";
 
 export { ReviewCard, MyReviewCard };
 
@@ -15,6 +17,7 @@ export default function ReviewCard({
   activeGoCollectionBtn?: boolean;
 }) {
   const defaultAvatarUrl = process.env.NEXT_PUBLIC_DEFAULT_AVATAR_URL;
+  const [selectedImageNum, setSelectedImageNum] = useState<number | null>(null);
 
   return (
     <article className={styles.review}>
@@ -44,6 +47,7 @@ export default function ReviewCard({
             alt="review image"
             width={100}
             height={100}
+            onClick={() => setSelectedImageNum(index)}
           />
         ))}
       </div>
@@ -69,11 +73,20 @@ export default function ReviewCard({
         )}
         <br />
       </div>
+      <ImageViewBox
+        selectedImageNum={selectedImageNum}
+        setSelectedImageNum={setSelectedImageNum}
+        review={reviewData.review}
+        membername={reviewData.writerMembername}
+        imagePaths={reviewData.imagePaths}
+      />
     </article>
   );
 }
 
 const MyReviewCard = ({ reviewData }: { reviewData: Pin }) => {
+  const [selectedImageNum, setSelectedImageNum] = useState<number | null>(null);
+
   return (
     <article className={styles.review}>
       {reviewData.review && (
@@ -93,10 +106,18 @@ const MyReviewCard = ({ reviewData }: { reviewData: Pin }) => {
               alt="review image"
               width={100}
               height={100}
+              onClick={() => setSelectedImageNum(index)}
             />
           ))}
         </div>
       )}
+      <ImageViewBox
+        selectedImageNum={selectedImageNum}
+        setSelectedImageNum={setSelectedImageNum}
+        review={reviewData.review}
+        membername={reviewData.writerMembername}
+        imagePaths={reviewData.imagePaths}
+      />
     </article>
   );
 };

--- a/src/containers/collection/CollectionEditPage.tsx
+++ b/src/containers/collection/CollectionEditPage.tsx
@@ -123,7 +123,7 @@ export default function CollectionEditPage({
     if (!success) {
       setAlertMessage(errorMessage);
     } else {
-      router.push(`/profile/${collectionInfo?.writerMembername}`);
+      router.replace(`/profile/${collectionInfo?.writerMembername}`);
     }
     setIsUploading(false);
   };
@@ -142,7 +142,7 @@ export default function CollectionEditPage({
       setAlertMessage(errorMessage);
       return;
     } else if (!imgFile) {
-      router.push(`/collection/${newCollectionId}`);
+      router.replace(`/collection/${newCollectionId}`);
       return;
     }
     // S3 이미지 업로드
@@ -167,7 +167,7 @@ export default function CollectionEditPage({
           setAlertMessage(errorMessage);
           return;
         }
-        router.push(`/collection/${newCollectionId}`);
+        router.replace(`/collection/${newCollectionId}`);
       }
     }
   };
@@ -218,7 +218,7 @@ export default function CollectionEditPage({
       }
     }
     clearDraftSave();
-    router.push(`/collection/${collectionId}`);
+    router.replace(`/collection/${collectionId}`);
   };
 
   /* 초기화 */

--- a/src/containers/collection/CollectionPage.tsx
+++ b/src/containers/collection/CollectionPage.tsx
@@ -113,7 +113,7 @@ export default function CollectionPage({
     if (!success) {
       dispatch(addAlertMessage(errorMessage));
     } else {
-      router.push(
+      router.replace(
         `/profile/${collectionFetchDatas.collectionInfo.writerMembername}`
       );
     }
@@ -181,7 +181,7 @@ export default function CollectionPage({
           pinFetchDatas.pinList?.map((pin) => pin.placeId || -1) || [],
       })
     );
-    router.push(`/pin/select?collectionId=${collectionId}`);
+    router.replace(`/pin/select?collectionId=${collectionId}`);
   };
 
   return (
@@ -190,7 +190,7 @@ export default function CollectionPage({
       completeButtonMsg={isMyCollection ? "수정" : undefined}
       deleteButtonMsg={isMyCollection ? "삭제" : undefined}
       onClickCompleteButton={() =>
-        router.push(`/collection/edit/${collectionId}`)
+        router.replace(`/collection/edit/${collectionId}`)
       }
       onClickDeleteButton={() => deleteCollection()}
     >

--- a/src/containers/collection/CollectionPage.tsx
+++ b/src/containers/collection/CollectionPage.tsx
@@ -113,7 +113,7 @@ export default function CollectionPage({
     if (!success) {
       dispatch(addAlertMessage(errorMessage));
     } else {
-      router.replace(
+      router.push(
         `/profile/${collectionFetchDatas.collectionInfo.writerMembername}`
       );
     }
@@ -181,7 +181,7 @@ export default function CollectionPage({
           pinFetchDatas.pinList?.map((pin) => pin.placeId || -1) || [],
       })
     );
-    router.replace(`/pin/select?collectionId=${collectionId}`);
+    router.push(`/pin/select?collectionId=${collectionId}`);
   };
 
   return (
@@ -190,7 +190,7 @@ export default function CollectionPage({
       completeButtonMsg={isMyCollection ? "수정" : undefined}
       deleteButtonMsg={isMyCollection ? "삭제" : undefined}
       onClickCompleteButton={() =>
-        router.replace(`/collection/edit/${collectionId}`)
+        router.push(`/collection/edit/${collectionId}`)
       }
       onClickDeleteButton={() => deleteCollection()}
     >

--- a/src/containers/collection/CollectionSelectPage.tsx
+++ b/src/containers/collection/CollectionSelectPage.tsx
@@ -134,7 +134,7 @@ const CollectionSelectPage = () => {
       const collectionTitle = collectionDataList.find(
         (collection) => collection.id === selectedCollection[0]
       )?.title;
-      router.push(
+      router.replace(
         `/pin/edit?placeId=${placeId}&placeName=${placeName}&collectionId=${selectedCollection[0]}&collectionTitle=${collectionTitle}`
       );
       return;
@@ -150,7 +150,7 @@ const CollectionSelectPage = () => {
     } else {
       setAlertMessage("핀이 추가되었습니다.");
       setSelectedCollection([]);
-      router.push(`/place/${placeId}`);
+      router.replace(`/place/${placeId}`);
     }
   };
 

--- a/src/containers/pin/PinEditPage.tsx
+++ b/src/containers/pin/PinEditPage.tsx
@@ -141,8 +141,8 @@ export default function PinEditPage({ pinId }: { pinId?: string }) {
       if (success) {
         dispatch(clearPinEditState());
         if (collectionEditId)
-          router.push(`/collection/edit/${collectionEditId}`);
-        else router.push(`/collection/${pinData.collectionId}`);
+          router.replace(`/collection/edit/${collectionEditId}`);
+        else router.replace(`/collection/${pinData.collectionId}`);
       }
     } else {
       const newPinId = await createPin();
@@ -151,8 +151,8 @@ export default function PinEditPage({ pinId }: { pinId?: string }) {
           await editPinWithImage(newPinId);
         }
         if (collectionEditId) {
-          router.push(`/collection/edit/${collectionEditId}`);
-        } else router.push(`/collection/${createInfo?.collectionId}`);
+          router.replace(`/collection/edit/${collectionEditId}`);
+        } else router.replace(`/collection/${createInfo?.collectionId}`);
       }
     }
     setIsLoading(false);
@@ -247,7 +247,7 @@ export default function PinEditPage({ pinId }: { pinId?: string }) {
     } else if (!imageFiles.length) {
       // 이미지 없이 핀 생성 성공
       dispatch(clearPinEditState());
-      router.push(`/collection/${createInfo.collectionId}`);
+      router.replace(`/collection/${createInfo.collectionId}`);
       return null;
     }
     return newPinId; // 핀 생성 성공 후 이미지 업로드
@@ -287,8 +287,8 @@ export default function PinEditPage({ pinId }: { pinId?: string }) {
     }
     setIsLoading(false);
     dispatch(clearPinEditState());
-    if (collectionEditId) router.push(`/collection/edit/${collectionEditId}`);
-    else router.push(`/collection/${pinData.collectionId}`);
+    if (collectionEditId) router.replace(`/collection/edit/${collectionEditId}`);
+    else router.replace(`/collection/${pinData.collectionId}`);
   };
 
   return (

--- a/src/containers/pin/PinEditPage.tsx
+++ b/src/containers/pin/PinEditPage.tsx
@@ -111,7 +111,7 @@ export default function PinEditPage({ pinId }: { pinId?: string }) {
       return;
     } else {
       const collectionEditId = searchParams.get("collectionEditId");
-      if (!collectionEditId || pinData.id === -1) router.back();
+      if (pinData.id === -1) router.back();
       if (collectionEditId) setCollectionEditId(collectionEditId);
       setImageFiles(
         pinData.imagePaths.map((imagePath, index) => ({
@@ -131,10 +131,6 @@ export default function PinEditPage({ pinId }: { pinId?: string }) {
     if (isLoading) return;
     setIsLoading(true);
     if (pinId) {
-      console.log(
-        "editPin",
-        imageFiles.find((imageFile) => imageFile.file !== null)
-      );
       const success = !imageFiles.find((imageFile) => imageFile.file !== null)
         ? await editPin()
         : await editPinWithImage(Number(pinId));
@@ -287,7 +283,8 @@ export default function PinEditPage({ pinId }: { pinId?: string }) {
     }
     setIsLoading(false);
     dispatch(clearPinEditState());
-    if (collectionEditId) router.replace(`/collection/edit/${collectionEditId}`);
+    if (collectionEditId)
+      router.replace(`/collection/edit/${collectionEditId}`);
     else router.replace(`/collection/${pinData.collectionId}`);
   };
 

--- a/src/containers/pin/PinSelectPage.tsx
+++ b/src/containers/pin/PinSelectPage.tsx
@@ -1,20 +1,14 @@
 "use client";
 
-import { useState, useEffect, SetStateAction } from "react";
-import { useSearchParams } from "next/navigation";
+import { useState, useEffect } from "react";
 import { addAlertMessage } from "@/redux/globalAlertSlice";
 import { useAppDispatch, useAppSelector } from "@/redux/hooks";
 import { useRouter } from "next/navigation";
 
 import styles from "@/styles/containers/pin/_pinSelectPage.module.scss";
 import { PlaceDetail } from "@/types/Place";
-import {
-  CheckRingRoundIcon,
-  CloseRoundIcon,
-  PinIcon,
-} from "@/components/IconSvg";
+import { CheckRingRoundIcon, PinIcon } from "@/components/IconSvg";
 import { SimplePlaceCard } from "@/components/PlaceCard";
-import { InputComponent } from "@/components/InputComponent";
 import { SlideMenu, SlideMenuInnerPage } from "@/components/SlideMenu";
 
 import fetchGetStars from "@/utils/stars/fetchGetStars";
@@ -110,7 +104,7 @@ const PinSelectPage = () => {
     );
     if (success) {
       dispatch(addAlertMessage("핀이 추가되었습니다."));
-      router.push(`/collection/${collectionId}`);
+      router.replace(`/collection/${collectionId}`);
     } else {
       dispatch(addAlertMessage(errorMessage));
     }

--- a/src/containers/profile/ProfileEditPage.tsx
+++ b/src/containers/profile/ProfileEditPage.tsx
@@ -163,7 +163,7 @@ export default function ProfileEditPage() {
     if (success) {
       updateReduxProfile();
       const membername = inputMembername;
-      router.push(`/profile/${membername}`);
+      router.replace(`/profile/${membername}`);
     } else setTotalErrorMessage(errorMessage);
   };
 

--- a/src/styles/components/_imageViewBox.module.scss
+++ b/src/styles/components/_imageViewBox.module.scss
@@ -1,0 +1,92 @@
+@import "../base/variables";
+
+.imageViewBox {
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	background-color: rgba(black, 0.7);
+	z-index: 11;
+	
+	display: flex;
+	align-content: center;
+	justify-content: center;
+}
+
+.imageViewContainer {
+	width: 70vw;
+	display: flex;
+	flex-direction: column;
+
+	align-items: center;
+	align-content: center;
+	justify-items: center;
+
+	.imageContainer {
+		position: relative;
+		display:flex;
+
+		justify-content: center;
+
+		margin-top: 10%;
+		width: 100%;
+		height: 70%;
+		.image {
+			object-fit: contain;
+			height: 100%;
+			// 이미지 드래그 막기
+			-webkit-user-select:none;
+			-moz-user-select:none;
+			-ms-user-select:none;
+			user-select:none
+		}
+		// buttons
+		.leftButton {
+			position: absolute;
+			top: 50%;
+			transform: translate(0, -50%);
+			left: -20%;
+			color: white;
+			cursor: pointer;
+			width: 2.5rem;
+			height: 2.5rem;
+		}
+		.rightButton {
+			position: absolute;
+			top: 50%;
+			transform: translate(0, -50%);
+			right: -20%;
+			color: white;
+			cursor: pointer;
+			width: 2.5rem;
+			height: 2.5rem;
+		}
+		.displayNoneButton {
+			display: none;
+		}
+	}
+	.reviewContainer {
+		width: 70vw;
+		padding: 1rem;
+		margin-top: 5%;
+		background-color: rgba(white, 0.7);
+		border-radius: $border-radius;
+		.membername {
+			font-weight: 600;
+			font-size: $font-size-smallest;
+		}
+		.review {
+			word-wrap: break-word;
+			overflow-wrap:break-word;
+		}
+	}
+}
+
+#closeButton {
+	position: absolute;
+	right: 5%;
+	top: 5%;
+	color: white;
+	cursor: pointer;
+}

--- a/src/styles/components/_review.module.scss
+++ b/src/styles/components/_review.module.scss
@@ -35,6 +35,7 @@
       width: 8rem;
       height: 8rem;
       object-fit: cover;
+      cursor: pointer
     }
   }
   .text {


### PR DESCRIPTION
<!--
  🚨PR 전에 해야할 것들🚨
  * PR 제목에 type 적기(ex Feature)
  * reviewer 등록하기
  * assignees 등록하기
  * label 붙이기
  * 브랜치 Merge 후 해당 브랜치 삭제하기
-->
## 🛠️ 변경 사항
-  ImageViewBox 구현
- 재접근 불가하도록 막는 페이지(핀 수정 페이지) push.replace 로 수정 
  - 적용된 페이지 : ProfileEdit, CollectionEdit, PinEdit, CollectionSelect, PinSelect

<br/>

## 📝 주의 사항 & 리뷰 요청

<br/>

## ⚡️ Issue number & Link
- #159 
- #171 

<br/>

## 📸 ScreenShot
<img width="1080" alt="image" src="https://github.com/PinTogether/frontend/assets/89989211/ddc68909-ebb2-405b-8ee3-454959df5cef">

<br/>
